### PR TITLE
Fix model access and update Gemini provider

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,7 +1,7 @@
-import { getAllModels } from "@/lib/models"
+import { getModelsWithAccessFlags } from "@/lib/models"
 
 export async function GET() {
-  const models = await getAllModels()
+  const models = await getModelsWithAccessFlags()
   return new Response(JSON.stringify({ models }), {
     status: 200,
     headers: { "Content-Type": "application/json" },
@@ -9,7 +9,7 @@ export async function GET() {
 }
 
 export async function POST() {
-  const models = await getAllModels()
+  const models = await getModelsWithAccessFlags()
   return Response.json({
     message: "Models cache refreshed",
     models,
@@ -17,4 +17,3 @@ export async function POST() {
     count: models.length,
   })
 }
-

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -11,16 +11,20 @@ export async function getAllModels(): Promise<ModelConfig[]> {
 export async function getModelsWithAccessFlags(): Promise<ModelConfig[]> {
   return STATIC_MODELS.map((m) => ({
     ...m,
-    accessible: FREE_MODELS_IDS.includes(m.id) || true,
+    accessible: FREE_MODELS_IDS.includes(m.id),
   }))
 }
 
-export async function getModelsForProvider(provider: string): Promise<ModelConfig[]> {
+export async function getModelsForProvider(
+  provider: string
+): Promise<ModelConfig[]> {
   if (provider === "google") return STATIC_MODELS
   return []
 }
 
-export async function getModelsForUserProviders(providers: string[]): Promise<ModelConfig[]> {
+export async function getModelsForUserProviders(
+  providers: string[]
+): Promise<ModelConfig[]> {
   return providers.includes("google") ? STATIC_MODELS : []
 }
 
@@ -33,4 +37,3 @@ export const MODELS: ModelConfig[] = STATIC_MODELS
 export function refreshModelsCache(): void {
   // no-op since models are static
 }
-

--- a/lib/openproviders/index.ts
+++ b/lib/openproviders/index.ts
@@ -1,18 +1,23 @@
-import { createGoogleGenerativeAI, google } from "@ai-sdk/google"
+import { createGoogleGenerativeAI } from "@ai-sdk/google"
 import type { LanguageModelV1 } from "@ai-sdk/provider"
 import type { GeminiModel, SupportedModel } from "./types"
 
-export type OpenProvidersOptions = Parameters<typeof google>[1]
+const GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com/v1"
+
+export type OpenProvidersOptions = Parameters<
+  ReturnType<typeof createGoogleGenerativeAI>
+>[1]
 
 export function openproviders<T extends SupportedModel>(
   modelId: T,
   settings?: OpenProvidersOptions,
   apiKey?: string
 ): LanguageModelV1 {
+  const options = { baseURL: GOOGLE_BASE_URL }
   if (apiKey) {
-    const provider = createGoogleGenerativeAI({ apiKey })
+    const provider = createGoogleGenerativeAI({ apiKey, ...options })
     return provider(modelId as GeminiModel, settings)
   }
-  return google(modelId as GeminiModel, settings)
+  const provider = createGoogleGenerativeAI(options)
+  return provider(modelId as GeminiModel, settings)
 }
-


### PR DESCRIPTION
## Summary
- expose `accessible` flag in `/api/models`
- set accessible based on `FREE_MODELS_IDS`
- use the v1 Google Generative AI API in `openproviders`

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6867add3768c83338230f4d22ad0895b