### PR TITLE
Fix system instruction field

### DIFF
--- a/lib/openproviders/index.ts
+++ b/lib/openproviders/index.ts
@@ -9,9 +9,9 @@ function withPatchedFetch(baseFetch: typeof fetch): typeof fetch {
     if (init?.body && typeof init.body === "string") {
       try {
         const payload = JSON.parse(init.body)
-        if (payload.systemInstruction && !payload.system_instruction) {
-          payload.system_instruction = payload.systemInstruction
-          delete payload.systemInstruction
+        if (payload.system_instruction && !payload.systemInstruction) {
+          payload.systemInstruction = payload.system_instruction
+          delete payload.system_instruction
           init.body = JSON.stringify(payload)
         }
       } catch {}


### PR DESCRIPTION
## Summary
- handle `system_instruction` vs `systemInstruction` in provider fetch

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm run type-check` *(fails: Cannot find module '@/lib/custom-system-prompt')*

------
https://chatgpt.com/codex/tasks/task_e_6867b81057dc8333a7b1eb01c0781bf2