### PR TITLE
Fix systemInstruction payload for Google API

### DIFF
--- a/lib/openproviders/index.ts
+++ b/lib/openproviders/index.ts
@@ -9,9 +9,9 @@ function withPatchedFetch(baseFetch: typeof fetch): typeof fetch {
     if (init?.body && typeof init.body === "string") {
       try {
         const payload = JSON.parse(init.body)
-        if (payload.system_instruction && !payload.systemInstruction) {
-          payload.systemInstruction = payload.system_instruction
-          delete payload.system_instruction
+        if (payload.systemInstruction && !payload.system_instruction) {
+          payload.system_instruction = payload.systemInstruction
+          delete payload.systemInstruction
           init.body = JSON.stringify(payload)
         }
       } catch {}


### PR DESCRIPTION
## Summary
- patch Google provider fetch to send `system_instruction` instead of `systemInstruction`

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run type-check` *(fails: Cannot find module '@/lib/custom-system-prompt')*

------
https://chatgpt.com/codex/tasks/task_e_6867c14c75fc833390927fb66c6b0ca4