### PR TITLE
Fix search grounding and add indicator

### DIFF
--- a/app/components/chat/message-assistant.tsx
+++ b/app/components/chat/message-assistant.tsx
@@ -7,7 +7,7 @@ import {
 import { useUserPreferences } from "@/lib/user-preference-store/provider"
 import { cn } from "@/lib/utils"
 import type { Message as MessageAISDK } from "@ai-sdk/react"
-import { ArrowClockwise, Check, Copy } from "@phosphor-icons/react"
+import { ArrowClockwise, Check, Copy, Globe } from "@phosphor-icons/react"
 import { getSources } from "./get-sources"
 import { Reasoning } from "./reasoning"
 import { SearchImages } from "./search-images"
@@ -63,6 +63,12 @@ export function MessageAssistant({
           : []
       ) ?? []
 
+  const usedWebSearch = toolInvocationParts?.some(
+    (part) =>
+      part.toolInvocation?.toolName === "googleSearch" ||
+      part.toolInvocation?.toolName === "googleSearchRetrieval"
+  )
+
   return (
     <Message
       className={cn(
@@ -87,6 +93,12 @@ export function MessageAssistant({
 
         {searchImageResults.length > 0 && (
           <SearchImages results={searchImageResults} />
+        )}
+
+        {usedWebSearch && (
+          <div className="text-muted-foreground flex items-center gap-1 text-xs">
+            <Globe className="size-3" /> Web search used
+          </div>
         )}
 
         {contentNullOrEmpty ? null : (

--- a/lib/openproviders/index.ts
+++ b/lib/openproviders/index.ts
@@ -7,11 +7,11 @@ const GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com/v1"
 async function getSystemPrompt() {
   try {
     // Use dynamic import to avoid circular dependencies
-    const config = await import('@/lib/config')
-    return config.SYSTEM_PROMPT_DEFAULT || ''
+    const config = await import("@/lib/config")
+    return config.SYSTEM_PROMPT_DEFAULT || ""
   } catch (error) {
-    console.error('Error loading system prompt:', error)
-    return ''
+    console.error("Error loading system prompt:", error)
+    return ""
   }
 }
 
@@ -22,10 +22,12 @@ function withPatchedFetch(baseFetch: typeof fetch): typeof fetch {
         const payload = JSON.parse(init.body)
 
         // Check if this is a Google Generative AI API request
-        const isGoogleAI = url.toString().includes('generativelanguage.googleapis.com')
-        
+        const isGoogleAI = url
+          .toString()
+          .includes("generativelanguage.googleapis.com")
+
         // Get system prompt from payload or use default
-        let systemContent = 
+        let systemContent =
           payload.system_instruction ||
           payload.systemInstruction ||
           payload.system
@@ -34,7 +36,7 @@ function withPatchedFetch(baseFetch: typeof fetch): typeof fetch {
         if (isGoogleAI && !systemContent) {
           systemContent = await getSystemPrompt()
         }
-        
+
         // Handle system instruction if we have one or it's a Google AI request
         if (systemContent || isGoogleAI) {
           if (isGoogleAI) {
@@ -58,11 +60,6 @@ function withPatchedFetch(baseFetch: typeof fetch): typeof fetch {
 
               // Remove the messages array as it's not needed
               delete payload.messages
-            }
-            
-            // Always remove tools field for Google AI as it's not supported
-            if ('tools' in payload) {
-              delete payload.tools
             }
           } else {
             // For other providers, maintain the messages array approach


### PR DESCRIPTION
## Summary
- ensure Google search tool isn't stripped from requests
- show when web search was used in assistant messages

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and other errors)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6867de1b723883338f56a6755d12c8fc